### PR TITLE
add region flag to account for non us-east-1 regions

### DIFF
--- a/course_scripts/main.tf
+++ b/course_scripts/main.tf
@@ -453,9 +453,9 @@ resource "aws_ami_from_instance" "wp_golden" {
     command = <<EOT
 cat <<EOF > userdata
 #!/bin/bash
-/usr/bin/aws s3 sync s3://${aws_s3_bucket.code.bucket} /var/www/html/
+/usr/bin/aws s3 sync s3://${aws_s3_bucket.code.bucket} --region ${var.aws_region} /var/www/html/
 /bin/touch /var/spool/cron/root
-sudo /bin/echo '*/5 * * * * aws s3 sync s3://${aws_s3_bucket.code.bucket} /var/www/html/' >> /var/spool/cron/root
+sudo /bin/echo '*/5 * * * * aws s3 sync s3://${aws_s3_bucket.code.bucket} --region ${var.aws_region} /var/www/html/' >> /var/spool/cron/root
 EOF
 EOT
   }

--- a/course_scripts/userdata
+++ b/course_scripts/userdata
@@ -1,4 +1,4 @@
 #!/bin/bash
-/usr/bin/aws s3 sync s3://bravethecloud_104 /var/www/html/
+/usr/bin/aws s3 sync s3://bravethecloud_104 --region us-east-1 /var/www/html/
 /bin/touch /var/spool/cron/root
-sudo /bin/echo '*/5 * * * * aws s3 sync s3://bravethecloud_104 /var/www/html/' >> /var/spool/cron/root
+sudo /bin/echo '*/5 * * * * aws s3 sync s3://bravethecloud_104 --region us-east-1 /var/www/html/' >> /var/spool/cron/root


### PR DESCRIPTION
i built my stack in us-east-2 and encountered an issue where the stock aws cli command reached out to S3 in us-east-1 without specifying.  This would ensure that wherever the stack is built it would be able to reach out to S3.

I also modified the userdata file for flavor and matched it with this stack's setting.